### PR TITLE
Make decor/Evented module to replace dojo/Evented.

### DIFF
--- a/Evented.js
+++ b/Evented.js
@@ -1,0 +1,39 @@
+/** @module decor/Evented */
+define(["dcl/dcl", "dcl/advise"], function (dcl, advise) {
+	/**
+	 * Base class to add on() and emit() methods to a class for listening for events and emitting events:
+	 * @example
+	 * var EventedSubClass = dcl(Evented, {...});
+	 * var instance = new EventedSubClass();
+	 * instance.on("open", function (event) {
+	 *     ... do something with event
+	 * });
+	 * instance.emit("open", {name:"some event", ...});
+	 * @mixin module:delite/Container
+	 * @augments module:delite/Widget
+	 */
+	return dcl(null, {
+		/**
+		 * Setup listener to be called when specified event is fired.
+		 * @param {string} type - Name of event.
+		 * @param {Function} listener - Callback for when event occurs.
+		 * @returns {Object} Handle with `remove()` method to stop listening to event.
+		 */
+		on: function (type, listener) {
+			return advise.before(this, "on" + type, listener);
+		},
+
+		/**
+		 * Emit specified event.
+		 * @param {string} type - Name of event.
+		 * @param {...anything} var_args Parameters to pass to the listeners for this event.
+		 */
+		emit: function (type) {
+			var func = "on" + type;
+			if (this[func]) {
+				var args = Array.prototype.slice.call(arguments, 1);
+				this[func].apply(this, args);
+			}
+		}
+	});
+});

--- a/tests/unit/Evented.js
+++ b/tests/unit/Evented.js
@@ -1,0 +1,30 @@
+define([
+	"intern!object",
+	"intern/chai!assert",
+	"dcl/dcl",
+	"decor/Evented"
+], function (registerSuite, assert, dcl, Evented) {
+	registerSuite({
+		name: "Evented",
+		basic: function () {
+			var MyClass = dcl(Evented, {});
+			var myObject = new MyClass();
+
+			// Make sure there's no exception if you emit an event that no one is listening to.
+			myObject.emit("nobody listening", 1, 2, 3);
+
+			// Test emitting events.  Make sure that parameters are passed to listeners.
+			var order = [];
+			var handle = myObject.on("custom", function (a, b, c) {
+				order.push(a, b, c);
+			});
+			myObject.emit("custom", 1, 2, 3);
+			assert.deepEqual(order, [1, 2, 3]);
+
+			// Make sure that calling unadvise() (or destroy()) stops the listener from getting notifications.
+			handle.unadvise();
+			myObject.emit("custom", 4, 5, 6);
+			assert.deepEqual(order, [1, 2, 3]);
+		}
+	});
+});


### PR DESCRIPTION
There are a lot of ways to make this module.  I copied the technique from
dojo, but we could alternately:
1. emit events on the document itself, and then use
   addEventListener()/removeEventListener() rather than dcl.advise()
2. hand craft the code to keep track of who is listening for what event
