### PR TITLE
Make sure computeProperties() runs when expected, fixes #12.

### DIFF
--- a/Invalidating.js
+++ b/Invalidating.js
@@ -26,14 +26,14 @@ define([
 			this.own(
 				this._hComputing = this.observe(function (oldValues) {
 					this.computeProperties(oldValues);
-					this.discardComputing();
+					this.deliverComputing();
 				}),
 				this._hRendering = this.observe(function (oldValues) {
 					this.refreshRendering(oldValues);
-					this.discardChanges();
 				})
 			);
-			this.discardChanges(); // Discard changes made by this function itself
+			// Discard changes made by this function itself (to ._hComputing and _hRendering)
+			this.discardChanges();
 		},
 
 		/**


### PR DESCRIPTION
This change makes sure pending change records created by `computeProperties()` are handled before `refreshProperties()` is called.

This may end up with `computeProperties()` being called multiple times. To avoid that, you can:

``` javascript
computeProperties: function (oldValues) {
    if ("prop0" in oldValues) {
        this.prop1 = this.prop0 + "Foo";
        this.discardComputing(); // We are sure prop1 change here is handled by next if() clause
    }
    if ("prop0" in oldValues || "prop1" in oldValues) {
        // prop0 or prop1 triggers prop2 change
        this.prop2 = this.prop1 + "Foo";
    }
}
```
