### PR TITLE
decor/sniff: add detection for Windows Phone

### DIFF
--- a/docs/sniff.md
+++ b/docs/sniff.md
@@ -22,10 +22,11 @@ The sniff module defines the following has-features:
 * `has("mozilla")` - mozilla based browser
 * `has("webkit")` - webkit based browser
 * `has("ff")` - firefox
-* `has("safari")` - safari (either on mac desktop or iOS)
+* `has("safari")` - safari (either on Mac desktop or iOS)
 * `has("chrome")` - chrome
-* `has("ios")` - truthy for iPhone, iPad, etc.
-* `has("android")` - true for android devices
+* `has("ios")` - truthy for iOS devices (iPhone, iPad, etc.)
+* `has("android")` - truthy for Android devices
+* `has("wp")` - truthy for Windows Phone devices
 * `has("mac")` - true for mac desktop
 * `has("msapp")` - app is running in Microsoft's container for stand alone web apps (similar to cordova).
 
@@ -34,22 +35,22 @@ The return value is only defined if the specified browser is being used.
 For example, if you're using Internet Explorer, only `has("ie")` is defined;
 all the other `has()` calls return undefined.
 
-`Has()` returns the browser version number as a number, so you can easily perform version checks.
+`has()` returns the browser version number as a number, so you can easily perform version checks.
 Additionally, since undefined always results in a false result in greater-than or less-than comparisons,
 you can use code like this to check for a certain browser version:
 
 
 ```js
-require(["decor/sniff"], function(has){
-	if(has("ie") <= 9){ // only IE9 and below
+require(["decor/sniff"], function(has) {
+	if (has("ie") <= 9) { // only IE9 and below
 	  ...
 	}
 
-	if(has("ff") < 24){ // only Firefox 24 and lower
+	if (has("ff") < 24) { // only Firefox 24 and lower
 	  ...
 	}
 
-	if(has("ie") == 10){ // only IE10
+	if (has("ie") == 10) { // only IE10
 	  ...
 	}
 });

--- a/sniff.js
+++ b/sniff.js
@@ -6,6 +6,7 @@
  * - `has("ie")`
  * - `has("ios")`
  * - `has("android")`
+ * - `had("wp")
  *
  * It returns the `has()` function.
  * @module decor/sniff

--- a/sniff.js
+++ b/sniff.js
@@ -67,6 +67,11 @@ define(["./features"], function (has) {
 		has.add("android", parseFloat(dua.split("Android ")[1]) || undefined);
 
 		has.add("msapp", parseFloat(dua.split("MSAppHost/")[1]) || undefined);
+
+		var wp = parseFloat(dua.split("Windows Phone ")[1]) || undefined;
+		if (wp) {
+			has.add("wp", wp);
+		}
 	}
 
 	return has;

--- a/sniff.js
+++ b/sniff.js
@@ -69,10 +69,7 @@ define(["./features"], function (has) {
 
 		has.add("msapp", parseFloat(dua.split("MSAppHost/")[1]) || undefined);
 
-		var wp = parseFloat(dua.split("Windows Phone ")[1]) || undefined;
-		if (wp) {
-			has.add("wp", wp);
-		}
+		has.add("wp", parseFloat(dua.split("Windows Phone ")[1]) || undefined);
 	}
 
 	return has;

--- a/tests/functional/sniff.html
+++ b/tests/functional/sniff.html
@@ -15,7 +15,7 @@
 			require({
 				baseUrl: "../../.."
 			}, ["decor/sniff", "requirejs-domready/domReady!"], function(has){
-				["webkit", "chrome", "safari", "ie", "mozilla", "ff", "ios", "android", "msapp"].forEach(
+				["webkit", "chrome", "safari", "ie", "mozilla", "ff", "ios", "android", "wp", "msapp"].forEach(
 						function (key) {
 					var res = has(key);
 					tbody.innerHTML += "<tr><td>has(\"" + key + "\")</td><td>" +

--- a/tests/unit/sniff.js
+++ b/tests/unit/sniff.js
@@ -6,7 +6,8 @@ define([
 	registerSuite({
 		name: "sniff",
 		sniff: function () {
-			assert(has("chrome") || has("safari") || has("ff") || has("ie") || has("ios") || has("android") ||
+			assert(has("chrome") || has("safari") || has("ff") || has("ie") ||
+				has("ios") || has("android") || has("wp") ||
 				!has("host-browser"),
 				"one browser's flag is set, or on node");
 		}


### PR DESCRIPTION
decor/sniff detects already iOS and Android, but doesn't detect the third supported mobile platform, Windows Phone. This would be necessary for instance for Combobox' support of Windows Phone.

Remarks:
* The name "wp" for the has-feature has been picked from a list of other candidates: "WindowsPhone" (seems we should stick to lower-case), "windowsphone" (unreadable), "windows-phone" (not bad, but longer; found at least one occurrence of dash separator in has-features in requirejs-dplugins; not sure we have explicite guidelines about naming pattern for has-features). @wkeese, if you prefer another name than the short "wp", just tell.
* Differently than the existing detection of "ios" and "android", I pllaced the detection for "wp" outside the webkit detection, for the reason see #30. 
* UA doc on WP: http://msdn.microsoft.com/en-us/library/ie/hh869301(v=vs.85).aspx
* Tested on both WP 8.0 and 8.1.