### PR TITLE
Sniff/fixing has("safari") on android stock browser

### DIFF
--- a/sniff.js
+++ b/sniff.js
@@ -20,12 +20,29 @@ define(["./features"], function (has) {
 			dav = n.appVersion,
 			tv = parseFloat(dav);
 
+
+		// Platform detection
+		has.add("mac", dav.indexOf("Macintosh") >= 0);
+		if (dua.match(/(iPhone|iPod|iPad)/)) {
+			var p = RegExp.$1.replace(/P/, "p");
+			var v = dua.match(/OS ([\d_]+)/) ? RegExp.$1 : "1";
+			var os = parseFloat(v.replace(/_/, ".").replace(/_/g, ""));
+			has.add(p, os);		// "iphone", "ipad" or "ipod"
+			has.add("ios", os);
+		}
+		has.add("android", parseFloat(dua.split("Android ")[1]) || undefined);
+
+		has.add("msapp", parseFloat(dua.split("MSAppHost/")[1]) || undefined);
+
+		has.add("wp", parseFloat(dua.split("Windows Phone ")[1]) || undefined);
+
+
 		// Browser detection
 		var webkit = parseFloat(dua.split("WebKit/")[1]) || undefined;
 		if (webkit) {
 			has.add("webkit", webkit);
 			has.add("chrome", parseFloat(dua.split("Chrome/")[1]) || undefined);
-			has.add("safari", dav.indexOf("Safari") >= 0 && !has("chrome") ?
+			has.add("safari", dav.indexOf("Safari") >= 0 && !has("chrome") && !has("android") ?
 				parseFloat(dav.split("Version/")[1]) : undefined);
 		} else {
 			var isIE = 0;
@@ -55,21 +72,6 @@ define(["./features"], function (has) {
 				has.add("ff", parseFloat(dua.split("Firefox/")[1] || dua.split("Minefield/")[1]) || undefined);
 			}
 		}
-
-		// Platform detection
-		has.add("mac", dav.indexOf("Macintosh") >= 0);
-		if (dua.match(/(iPhone|iPod|iPad)/)) {
-			var p = RegExp.$1.replace(/P/, "p");
-			var v = dua.match(/OS ([\d_]+)/) ? RegExp.$1 : "1";
-			var os = parseFloat(v.replace(/_/, ".").replace(/_/g, ""));
-			has.add(p, os);		// "iphone", "ipad" or "ipod"
-			has.add("ios", os);
-		}
-		has.add("android", parseFloat(dua.split("Android ")[1]) || undefined);
-
-		has.add("msapp", parseFloat(dua.split("MSAppHost/")[1]) || undefined);
-
-		has.add("wp", parseFloat(dua.split("Windows Phone ")[1]) || undefined);
 	}
 
 	return has;

--- a/tests/functional/all.js
+++ b/tests/functional/all.js
@@ -1,1 +1,3 @@
-define([ ]);
+define([
+	"./sniff"
+]);

--- a/tests/functional/sniff.html
+++ b/tests/functional/sniff.html
@@ -1,5 +1,8 @@
 <html>
 	<head>
+		<meta http-equiv="content-type" content="text/html; charset=utf-8"/>
+		<meta name="viewport" content="width=device-width,initial-scale=1,maximum-scale=1,minimum-scale=1,user-scalable=no" />
+		<meta name="apple-mobile-web-app-capable" content="yes" />
 		<title>decor/sniff test</title>
 		<style>
 			table {
@@ -12,15 +15,23 @@
 		</style>
 		<script src="../../../requirejs/require.js"></script>
 		<script>
+			var ready = false; // set to true when the test page is ready
 			require({
 				baseUrl: "../../.."
 			}, ["decor/sniff", "requirejs-domready/domReady!"], function(has){
-				["webkit", "chrome", "safari", "ie", "mozilla", "ff", "ios", "android", "wp", "msapp"].forEach(
-						function (key) {
+				window._has = {};
+				[
+					"webkit", "chrome", "android",
+					"ie",  "msapp", "wp",
+					"mozilla", "ff",
+					"safari", "iphone", "ipad", "mac", "ios"
+				].forEach(function (key) {
+					window._has[key] = has(key);
 					var res = has(key);
 					tbody.innerHTML += "<tr><td>has(\"" + key + "\")</td><td>" +
 						(res === undefined ? "undefined" : res) + "</td></tr>";
 				});
+				ready = true;
 			});
 		</script>
 	</head>

--- a/tests/functional/sniff.html
+++ b/tests/functional/sniff.html
@@ -15,22 +15,33 @@
 		</style>
 		<script src="../../../requirejs/require.js"></script>
 		<script>
-			var ready = false; // set to true when the test page is ready
+			var ready = false, // set to true when the test page is ready
+				_has = {};
 			require({
 				baseUrl: "../../.."
 			}, ["decor/sniff", "requirejs-domready/domReady!"], function(has){
-				window._has = {};
-				[
+				var tbody = document.getElementById("tbody");
+
+
+				var browsers = [
 					"webkit", "chrome", "android",
 					"ie",  "msapp", "wp",
 					"mozilla", "ff",
 					"safari", "iphone", "ipad", "mac", "ios"
-				].forEach(function (key) {
-					window._has[key] = has(key);
-					var res = has(key);
-					tbody.innerHTML += "<tr><td>has(\"" + key + "\")</td><td>" +
-						(res === undefined ? "undefined" : res) + "</td></tr>";
-				});
+				];
+				for (var i = 0, n = browsers.length; i < n; i++) {
+					var key = browsers[i];
+					_has[key] = has(key);
+					var tr = document.createElement("tr"),
+						tdkey = document.createElement("td"),
+						tdres = document.createElement("td");
+
+					tdkey.innerHTML = 'has("' + key + '")';
+					tdres.innerHTML = _has[key] === undefined ? "undefined" : _has[key];
+					tr.appendChild(tdkey);
+					tr.appendChild(tdres);
+					tbody.appendChild(tr);		
+				}
 				ready = true;
 			});
 		</script>

--- a/tests/functional/sniff.js
+++ b/tests/functional/sniff.js
@@ -1,0 +1,69 @@
+define(["intern",
+	"intern!object",
+	"intern/dojo/node!leadfoot/helpers/pollUntil",
+	"intern/chai!assert",
+	"require",
+], function (intern, registerSuite, pollUntil, assert, require) {
+	var PAGE = "./sniff.html";
+
+	registerSuite({
+		name: "Sniff tests",
+		setup: function () {},
+
+		"Checking browser and platform sniffing": function () {
+			this.timeout = intern.config.TEST_TIMEOUT;
+			var remote = this.remote;
+			return remote
+				.get(require.toUrl(PAGE))
+				.then(pollUntil("return ('ready' in window && ready) ? true : null;", [],
+						intern.config.WAIT_TIMEOUT, intern.config.POLL_INTERVAL))
+				.execute("return _has")
+				.then(function (has) {
+					function shouldDetectOnly(expected) {
+						Object.keys(has).forEach(function (browser) {
+							if (expected.indexOf(browser) > -1) {
+								assert.ok(has[browser], "detected " + browser + " as expected");
+							} else {
+								assert.notOk(has[browser], "didn't detect " + browser + " as expected");
+							}
+						});
+					}
+
+					var browserName = remote.environmentType.browserName,
+						platform = remote.environmentType.platform,
+						deviceName = remote.environmentType.deviceName;
+
+					switch (browserName) {
+					case "chrome":
+						shouldDetectOnly(["chrome", "webkit"]);
+						break;
+					case "internet explorer":
+						shouldDetectOnly(["ie"]);
+						break;
+					case "firefox":
+						shouldDetectOnly(["ff", "mozilla"]);
+						break;
+					case "safari":
+						switch (platform) {
+						case "MAC":
+							shouldDetectOnly(["safari", "webkit", "mac"]);
+							break;
+						}
+						break;
+					case "iOS":
+						switch (deviceName) {
+						case "iPad Simulator":
+							shouldDetectOnly(["safari", "webkit", "ios", "ipad"]);
+							break;
+						case "iPhone Simulator":
+							shouldDetectOnly(["safari", "webkit", "ios", "iphone"]);
+							break;
+						}
+						break;
+
+					}
+				})
+				.end();
+		},
+	});
+});


### PR DESCRIPTION
This fixes #24. 
I also added an automated test that confronts the output of has with the capabilities data.

NOTE: I wasn't able to obtain a valid travis build due to the tests on sauce lab constantly timouting.
I did test it on saucelab though, one or a couple of browsers at a time, and it worked. So i'll just wait and try again later.
In the mean time, feedback is welcome.