### PR TITLE
Adapt doc layout to fix the navigation of ibm-js.github.io

### DIFF
--- a/docs/Destroyable.md
+++ b/docs/Destroyable.md
@@ -1,5 +1,5 @@
 ---
-layout: default
+layout: doc
 title: decor/Destroyable
 ---
 

--- a/docs/Evented.md
+++ b/docs/Evented.md
@@ -1,5 +1,5 @@
 ---
-layout: default
+layout: doc
 title: decor/Evented
 ---
 

--- a/docs/Invalidating.md
+++ b/docs/Invalidating.md
@@ -1,5 +1,5 @@
 ---
-layout: default
+layout: doc
 title: decor/Invalidating
 ---
 

--- a/docs/Observable.md
+++ b/docs/Observable.md
@@ -1,5 +1,5 @@
 ---
-layout: default
+layout: doc
 title: decor/Observable - A shim of ES7 Object.observe() by value-holder object
 ---
 

--- a/docs/Stateful.md
+++ b/docs/Stateful.md
@@ -1,5 +1,5 @@
 ---
-layout: default
+layout: doc
 title: decor/Stateful
 ---
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,5 +1,5 @@
 ---
-layout: default
+layout: doc
 title: Decor Architecture
 ---
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,5 +1,5 @@
 ---
-layout: doc
+layout: docMain
 ---
 
 The decor project contains some classes and utilities that are not directly related to UI.

--- a/docs/schedule.md
+++ b/docs/schedule.md
@@ -1,5 +1,5 @@
 ---
-layout: default
+layout: doc
 title: decor/schedule
 ---
 

--- a/docs/sniff.md
+++ b/docs/sniff.md
@@ -1,5 +1,5 @@
 ---
-layout: default
+layout: doc
 title: decor/sniff
 ---
 


### PR DESCRIPTION
This is to fix the menu of ibm-js.github.io.

If you navigate to http://ibm-js.github.io/decor/docs/master/Invalidating.html you can see that the `Docs` item in the menu is not highlighted.