### PR TITLE
Observable.assign() better aligning to Object.assign() spec.

### DIFF
--- a/Observable.js
+++ b/Observable.js
@@ -122,8 +122,12 @@ define([
 	 * @returns {Object} The target object.
 	 */
 	Observable.assign = function (dst) {
+		if (dst == null) {
+			throw new TypeError("Can't convert " + dst + " to object.");
+		}
+		dst = Object(dst);
 		for (var hasDstSetter = typeof dst.set === "function", i = 1, l = arguments.length; i < l; ++i) {
-			var src = arguments[i],
+			var src = Object(arguments[i]),
 				props = Object.getOwnPropertyNames(src);
 			for (var j = 0, m = props.length; j < m; ++j) {
 				var prop = props[j];

--- a/tests/unit/schedule.js
+++ b/tests/unit/schedule.js
@@ -5,7 +5,7 @@ define([
 ], function (registerSuite, assert, schedule) {
 	var handles = [];
 	registerSuite({
-		name: "Observable",
+		name: "schedule",
 		afterEach: function () {
 			for (var handle = null; (handle = handles.shift());) {
 				handle.remove();


### PR DESCRIPTION
https://people.mozilla.org/~jorendorff/es6-draft.html#sec-object.assign

* Throw error if `undefined` or `null` is set to `dst`
* Both `dst`/`src` should be converted to object before iterating through properties, and should return such converted version of `dst`