### PR TITLE
process.nextTick() support in decor/Schedule, fixes ibm-js/delite#402.

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -14,7 +14,8 @@ module.exports = function (grunt) {
 			node: {
 				options: {
 					runType: "client",
-					config: "tests/intern"
+					config: "tests/intern",
+					reporters: ["console"]
 				}
 			},
 			local: {

--- a/features.js
+++ b/features.js
@@ -1,9 +1,10 @@
 define(["requirejs-dplugins/has"], function (has) {
-	/* global Platform */
+	/* global process, Platform */
 	has.add("console-api", typeof console !== "undefined");
 	has.add("host-browser", typeof window !== "undefined");
 	has.add("object-observe-api", typeof Object.observe === "function" && typeof Array.observe === "function");
 	has.add("object-is-api", Object.is);
+	has.add("nexttick-api", typeof process === "object" && typeof process.nextTick === "function");
 	has.add("setimmediate-api", typeof setImmediate === "function");
 	has.add("mutation-observer-api",
 		typeof MutationObserver !== "undefined"

--- a/schedule.js
+++ b/schedule.js
@@ -8,48 +8,67 @@ define(["./features"], function (has) {
 	 * @param {Function} callback The function to call at the end of microtask.
 	 */
 
-	/* global setImmediate */
-	var inFlight,
-		SCHEDULEID_PREFIX = "_schedule",
-		seq = 0,
-		uniqueId = Math.random() + "",
-		callbacks = {},
-		pseudoDiv = has("mutation-observer-api") && document.createElement("div");
-	function runCallbacks() {
-		for (var anyWorkDone = true; anyWorkDone;) {
-			anyWorkDone = false;
-			for (var id in callbacks) {
-				var callback = callbacks[id];
-				delete callbacks[id];
-				callback();
-				anyWorkDone = true;
-			}
-		}
-		inFlight = false;
-	}
-	if (has("mutation-observer-api")) {
-		pseudoDiv.id = 0;
-		new MutationObserver(runCallbacks).observe(pseudoDiv, {attributes: true});
-	} else if (!has("setimmediate-api")) {
-		window.addEventListener("message", function (event) {
-			if (event.data === uniqueId) {
-				runCallbacks();
-			}
-		});
-	}
-	return function (callback) {
-		var id = SCHEDULEID_PREFIX + seq++;
-		callbacks[id] = callback;
-		if (!inFlight) {
-			has("mutation-observer-api") ? ++pseudoDiv.id :
-				has("setimmediate-api") ? setImmediate(runCallbacks) :
-				window.postMessage(uniqueId, "*");
-			inFlight = true;
-		}
-		return {
-			remove: function () {
-				delete callbacks[id];
-			}
+	if (has("nexttick-api")) {
+		// node.js process.nextTick() puts a callback to micro-task queue, which is exactly what decor/schedule desires
+		/* global process */
+		return function (callback) {
+			var canceled;
+			process.nextTick(function () {
+				if (!canceled) {
+					callback();
+				}
+			});
+			return {
+				remove: function () {
+					canceled = true;
+				}
+			};
 		};
-	};
+	} else {
+		/* global setImmediate */
+		var inFlight,
+			SCHEDULEID_PREFIX = "_schedule",
+			seq = 0,
+			uniqueId = Math.random() + "",
+			callbacks = {},
+			pseudoDiv = has("mutation-observer-api") && document.createElement("div"),
+			runCallbacks = function () {
+				for (var anyWorkDone = true; anyWorkDone;) {
+					anyWorkDone = false;
+					for (var id in callbacks) {
+						var callback = callbacks[id];
+						delete callbacks[id];
+						callback();
+						anyWorkDone = true;
+					}
+				}
+				inFlight = false;
+			};
+		if (has("mutation-observer-api")) {
+			pseudoDiv.id = 0;
+			new MutationObserver(runCallbacks).observe(pseudoDiv, {attributes: true});
+		} else if (!has("setimmediate-api") && typeof window !== "undefined") {
+			window.addEventListener("message", function (event) {
+				if (event.data === uniqueId) {
+					runCallbacks();
+				}
+			});
+		}
+		return function (callback) {
+			var id = SCHEDULEID_PREFIX + seq++;
+			callbacks[id] = callback;
+			if (!inFlight) {
+				has("mutation-observer-api") ? ++pseudoDiv.id :
+					has("setimmediate-api") ? setImmediate(runCallbacks) :
+					typeof window !== "undefined" ? window.postMessage(uniqueId, "*") :
+					setTimeout(runCallbacks, 0);
+				inFlight = true;
+			}
+			return {
+				remove: function () {
+					delete callbacks[id];
+				}
+			};
+		};
+	}
 });

--- a/tests/intern.js
+++ b/tests/intern.js
@@ -54,7 +54,7 @@ define({
 	},
 
 	useLoader: {
-		"host-node": "requirejs",
+		"host-node": "dojo/dojo", // Dojo inside Intern, for node.js testing
 		"host-browser": "../../../requirejs/require.js"
 	},
 


### PR DESCRIPTION
For node.js environment. `setImmediate()` is not available node.js < 0.9. Also - `setImmediate()` runs after painting, etc. stuffs happens, whereas end-of-microtask queue like `process.nextTick()` and Mutation Observer callbacks runs before painting, etc. stuffs.