### PR TITLE
Invalidating enhancements (for dynamic templates)

### DIFF
--- a/Invalidating.js
+++ b/Invalidating.js
@@ -36,7 +36,7 @@ define([
 
 		/**
 		 * Synchronously deliver change records for computed properties
-		 * so that `refreshingComputing()` is called if there are pending change records.
+		 * so that `computeProperties()` is called if there are pending change records.
 		 */
 		deliverComputing: function () {
 			this._hComputing && this._hComputing.deliver();
@@ -49,6 +49,23 @@ define([
 		discardComputing: function () {
 			this._hComputing && this._hComputing.discardChanges();
 			return this._hComputing;
+		},
+
+		/**
+		 * Synchronously deliver change records to render UI changes
+		 * so that `refreshingRendering()` is called if there are pending change records.
+		 */
+		deliverRendering: function () {
+			this._hRendering && this._hRendering.deliver();
+			return this._hRendering;
+		},
+
+		/**
+		 * Discard change records to render UI changes.
+		 */
+		discardRendering: function () {
+			this._hRendering && this._hRendering.discardChanges();
+			return this._hRendering;
 		},
 
 		/**

--- a/Invalidating.js
+++ b/Invalidating.js
@@ -26,24 +26,29 @@ define([
 		 */
 		initializeInvalidating: function () {
 			if (!this._hComputing && !this._hRendering) {
+				// Make initial call to computeProperties() and setup listener for future calls to computeProperties().
+				// Any call to computeProperties(), including the initial call, may trigger more immediate calls to
+				// computeProperties().
+				this.own(this._hComputing = this.observe(function (oldValues) {
+					this.computeProperties(oldValues);
+					this.deliverComputing();
+				}));
 				this.computeProperties(this, true);
+
+				// Make initial call to initializeRendering() and refreshRendering(), and setup listener for future
+				// calls.
 				this.initializeRendering(this);
 				this.refreshRendering(this, true);
-				this.own(
-					this._hComputing = this.observe(function (oldValues) {
-						this.computeProperties(oldValues);
-						this.deliverComputing();
-					}),
-					this._hRendering = this.observe(function (oldValues) {
-						var shouldInitializeRendering = this.shouldInitializeRendering(oldValues);
-						if (shouldInitializeRendering) {
-							this.initializeRendering(oldValues);
-							this.refreshRendering(this, true);
-						} else {
-							this.refreshRendering(oldValues);
-						}
-					})
-				);
+				this.own(this._hRendering = this.observe(function (oldValues) {
+					var shouldInitializeRendering = this.shouldInitializeRendering(oldValues);
+					if (shouldInitializeRendering) {
+						this.initializeRendering(oldValues);
+						this.refreshRendering(this, true);
+					} else {
+						this.refreshRendering(oldValues);
+					}
+				}));
+
 				// Discard changes made by this function itself (to ._hComputing and _hRendering)
 				this.discardChanges();
 			}

--- a/Invalidating.js
+++ b/Invalidating.js
@@ -27,7 +27,11 @@ define([
 					this.deliverComputing();
 				}),
 				this._hRendering = this.observe(function (oldValues) {
-					this.refreshRendering(oldValues);
+					var shouldInitializeRendering = this.shouldInitializeRendering(oldValues);
+					if (shouldInitializeRendering) {
+						this.initializeRendering(oldValues);
+					}
+					this.refreshRendering(oldValues, shouldInitializeRendering);
 				})
 			);
 			// Discard changes made by this function itself (to ._hComputing and _hRendering)
@@ -69,16 +73,29 @@ define([
 		},
 
 		/**
+		 * Function to return if rendering should be initialized.
+		 * (Instead of making partial changes for post-initialization)
+		 * @param {Object} oldValues The hash table of old property values, keyed by property names.
+		 * @return {boolean} True if rendering should be initialized.
+		 */
+		shouldInitializeRendering: function () {},
+
+		/**
 		 * Callback function to calculate computed properties upon property changes.
-		 * @param {Object} newValues The hash table of new property values, keyed by property names.
 		 * @param {Object} oldValues The hash table of old property values, keyed by property names.
 		 */
 		computeProperties: function () {},
 
 		/**
-		 * Callback function to render UI upon property changes.
-		 * @param {Object} newValues The hash table of new property values, keyed by property names.
+		 * Callback function to initialize rendering.
 		 * @param {Object} oldValues The hash table of old property values, keyed by property names.
+		 */
+		initializeRendering: function () {},
+
+		/**
+		 * Callback function to render UI upon property changes.
+		 * @param {Object} oldValues The hash table of old property values, keyed by property names.
+		 * @param {boolean} isAfterInitialRendering True if this call is right after `initializeRendering()`.
 		 */
 		refreshRendering: function () {}
 	});

--- a/Invalidating.js
+++ b/Invalidating.js
@@ -21,21 +21,29 @@ define([
 		 * @protected
 		 */
 		initializeInvalidating: function () {
-			this.own(
-				this._hComputing = this.observe(function (oldValues) {
-					this.computeProperties(oldValues);
-					this.deliverComputing();
-				}),
-				this._hRendering = this.observe(function (oldValues) {
-					var shouldInitializeRendering = this.shouldInitializeRendering(oldValues);
-					if (shouldInitializeRendering) {
-						this.initializeRendering(oldValues);
-					}
-					this.refreshRendering(oldValues, shouldInitializeRendering);
-				})
-			);
-			// Discard changes made by this function itself (to ._hComputing and _hRendering)
-			this.discardChanges();
+			if (!this._hComputing && !this._hRendering) {
+				this.computeProperties(this, true);
+				var shouldInitializeRendering = this.shouldInitializeRendering(this, true);
+				if (shouldInitializeRendering) {
+					this.initializeRendering(this);
+				}
+				this.refreshRendering(this, shouldInitializeRendering);
+				this.own(
+					this._hComputing = this.observe(function (oldValues) {
+						this.computeProperties(oldValues);
+						this.deliverComputing();
+					}),
+					this._hRendering = this.observe(function (oldValues) {
+						var shouldInitializeRendering = this.shouldInitializeRendering(oldValues);
+						if (shouldInitializeRendering) {
+							this.initializeRendering(oldValues);
+						}
+						this.refreshRendering(oldValues, shouldInitializeRendering);
+					})
+				);
+				// Discard changes made by this function itself (to ._hComputing and _hRendering)
+				this.discardChanges();
+			}
 		},
 
 		/**
@@ -76,6 +84,7 @@ define([
 		 * Function to return if rendering should be initialized.
 		 * (Instead of making partial changes for post-initialization)
 		 * @param {Object} oldValues The hash table of old property values, keyed by property names.
+		 * @param {boolean} isAfterCreation True if this call is right after instantiation.
 		 * @return {boolean} True if rendering should be initialized.
 		 */
 		shouldInitializeRendering: function () {},
@@ -83,6 +92,7 @@ define([
 		/**
 		 * Callback function to calculate computed properties upon property changes.
 		 * @param {Object} oldValues The hash table of old property values, keyed by property names.
+		 * @param {boolean} isAfterCreation True if this call is right after instantiation.
 		 */
 		computeProperties: function () {},
 

--- a/Invalidating.js
+++ b/Invalidating.js
@@ -48,9 +48,6 @@ define([
 						this.refreshRendering(oldValues);
 					}
 				}));
-
-				// Discard changes made by this function itself (to ._hComputing and _hRendering)
-				this.discardChanges();
 			}
 		},
 

--- a/Invalidating.js
+++ b/Invalidating.js
@@ -1,17 +1,26 @@
 /** @module decor/Invalidating */
 define([
 	"dcl/dcl",
-	"./schedule",
 	"./Stateful",
 	"./Destroyable"
-], function (dcl, schedule, Stateful, Destroyable) {
+], function (dcl, Stateful, Destroyable) {
 	/**
 	 * Mixin class for widgets
 	 * that want to calculate computed properties at once and/or to render UI at once upon multiple property changes.
 	 * @class module:decor/Invalidating
 	 */
 	var Invalidating = dcl([Stateful, Destroyable], /** @lends module:decor/Invalidating# */ {
-		_initializeInvalidating: function () {
+		constructor: dcl.after(function () {
+			this.initializeInvalidating();
+		}),
+
+		/**
+		 * Sets up observers, one for computed properties, one for UI rendering.
+		 * Normally this method is called automatically by the constructor, and should not be called manually,
+		 * but the method is exposed for custom elements since they do not call the `constructor()` method.
+		 * @protected
+		 */
+		initializeInvalidating: function () {
 			if (!this._hComputing && !this._hRendering) {
 				this.computeProperties(this, true);
 				var shouldInitializeRendering = this.shouldInitializeRendering(this, true);
@@ -36,35 +45,6 @@ define([
 				this.discardChanges();
 			}
 		},
-
-		constructor: dcl.after(function () {
-			this.initializeInvalidating();
-		}),
-
-		/**
-		 * Sets up observers, one for computed properties, one for UI rendering.
-		 * Normally this method is called automatically by the constructor, and should not be called manually,
-		 * but the method is exposed for custom elements since they do not call the `constructor()` method.
-		 * @protected
-		 */
-		initializeInvalidating: function () {
-			if (!this._hInitializeInvalidating) {
-				this._hInitializeInvalidating = schedule(this._initializeInvalidating.bind(this));
-			}
-		},
-
-		/**
-		 * Synchronously deliver pending change records.
-		 * If there is pending observer setup, do that in addition.
-		 */
-		deliver: dcl.after(function () {
-			if (this._hInitializeInvalidating) {
-				this._initializeInvalidating();
-				this._hInitializeInvalidating.remove();
-				delete this._hInitializeInvalidating;
-				this.discardChanges();
-			}
-		}),
 
 		/**
 		 * Synchronously deliver change records for computed properties

--- a/Invalidating.js
+++ b/Invalidating.js
@@ -1,26 +1,17 @@
 /** @module decor/Invalidating */
 define([
 	"dcl/dcl",
+	"./schedule",
 	"./Stateful",
 	"./Destroyable"
-], function (dcl, Stateful, Destroyable) {
+], function (dcl, schedule, Stateful, Destroyable) {
 	/**
 	 * Mixin class for widgets
 	 * that want to calculate computed properties at once and/or to render UI at once upon multiple property changes.
 	 * @class module:decor/Invalidating
 	 */
 	var Invalidating = dcl([Stateful, Destroyable], /** @lends module:decor/Invalidating# */ {
-		constructor: dcl.after(function () {
-			this.initializeInvalidating();
-		}),
-
-		/**
-		 * Sets up observers, one for computed properties, one for UI rendering.
-		 * Normally this method is called automatically by the constructor, and should not be called manually,
-		 * but the method is exposed for custom elements since they do not call the `constructor()` method.
-		 * @protected
-		 */
-		initializeInvalidating: function () {
+		_initializeInvalidating: function () {
 			if (!this._hComputing && !this._hRendering) {
 				this.computeProperties(this, true);
 				var shouldInitializeRendering = this.shouldInitializeRendering(this, true);
@@ -45,6 +36,35 @@ define([
 				this.discardChanges();
 			}
 		},
+
+		constructor: dcl.after(function () {
+			this.initializeInvalidating();
+		}),
+
+		/**
+		 * Sets up observers, one for computed properties, one for UI rendering.
+		 * Normally this method is called automatically by the constructor, and should not be called manually,
+		 * but the method is exposed for custom elements since they do not call the `constructor()` method.
+		 * @protected
+		 */
+		initializeInvalidating: function () {
+			if (!this._hInitializeInvalidating) {
+				this._hInitializeInvalidating = schedule(this._initializeInvalidating.bind(this));
+			}
+		},
+
+		/**
+		 * Synchronously deliver pending change records.
+		 * If there is pending observer setup, do that in addition.
+		 */
+		deliver: dcl.after(function () {
+			if (this._hInitializeInvalidating) {
+				this._initializeInvalidating();
+				this._hInitializeInvalidating.remove();
+				delete this._hInitializeInvalidating;
+				this.discardChanges();
+			}
+		}),
 
 		/**
 		 * Synchronously deliver change records for computed properties

--- a/Invalidating.js
+++ b/Invalidating.js
@@ -72,23 +72,6 @@ define([
 		},
 
 		/**
-		 * Synchronously deliver change records to render UI changes
-		 * so that `refreshingRendering()` is called if there are pending change records.
-		 */
-		deliverRendering: function () {
-			this._hRendering && this._hRendering.deliver();
-			return this._hRendering;
-		},
-
-		/**
-		 * Discard change records to render UI changes.
-		 */
-		discardRendering: function () {
-			this._hRendering && this._hRendering.discardChanges();
-			return this._hRendering;
-		},
-
-		/**
 		 * Function to return if rendering should be initialized.
 		 * (Instead of making partial changes for post-initialization)
 		 * @param {Object} oldValues The hash table of old property values, keyed by property names.

--- a/docs/Invalidating.md
+++ b/docs/Invalidating.md
@@ -6,41 +6,73 @@ title: decor/Invalidating
 # decor/Invalidating
 
 `decor/Invalidating` is a mixin class to for UI-related Custom Elements
-that want to calculate computed properties at once and/or to render UI at once upon multiple property changes.
+that want to calculate computed properties once, and/or render the UI once, upon multiple property changes.
+For that purpose the class adds two main lifecycle phases to the class, `computeProperties()` and
+`refreshRendering()`, which are both called after a batch of property changes.
+
 Invalidating extends `decor/Stateful`, and `delite/Widget` extends Invalidating.
-
-For that purpose the class adds two lifecycle phases to the class.
-
-The first phase is the refresh properties phase. It is used to reconcile instances properties after they have been
-set. A typical example is making sure the value of a range component is correctly set between min and max values and
-that the max value is bigger than min value. This phase is optional and not all classes leveraging `decor/Invalidating`
-will need it.
-
-The second phase is the refresh rendering phase. It is used to refresh the rendering of the class (usually a
-`delite/Widget`) based on the new values of the changed properties. The advantage compared to doing that in a custom setter
-or through template binding is that for several properties changes the refresh rendering phase will be called only once
-leading to better performance by making sure the rendering is not modified several times in a row
 
 ##### Table of Contents
 [Setting Up Invalidating](#setting)  
-[Implementing Lifecycle](#implementing)  
+[Changes Lifecycle](#changes)  
+[Startup Lifecycle](#startup)  
+[Implementing a Subclass](#implementing)  
 [Using Invalidating](#using)  
+[Rerendering From Scratch](#rerender)  
 
 <a name="setting"></a>
 ## Setting up Invalidating
 
-Note that in order to be subject to invalidation the corresponding property must also haven been declared on the class.
+Note that in order to be subject to invalidation the corresponding property must also haven been declared in the class.
 
-Note that any property subject to refresh properties phase will also be subject to the refresh rendering phase in a
+Note that any property subject to compute properties phase will also be subject to the refresh rendering phase in a
 second phase.
 
-<a name="implementing"></a>
-## Implementing the Lifecycle
+<a name="changes"></a>
+## Changes Lifecycle
 
-Once you have setup your class, you will need to implement the lifecycle functions in order to react to property changes.
-This can be done by redefining the `computeProperties()` and/or `refreshRendering()` functions. They both take as
-parameter a hash object which contains the name of the properties that have triggered the refresh action. This is
-particularly useful when several properties are involved.
+After a batch of changes, `decor/Invalidating` goes through two phases of processing: `computeProperties()` and
+`refreshRendering()`.
+
+The first phase, `computeProperties()`, is used to reconcile instances properties after they have been set.
+A typical example is making sure the value of a range component is correctly set between min and max values and
+that the max value is bigger than min value.
+This phase is optional and not all classes leveraging `decor/Invalidating` will need it.
+This phase can also be used to compute values for properties derived from other properties, such as an employee's
+name which is "calculated" from the first name and last name.
+
+The second phase, `refreshRendering()`, is used to update the rendering of the class (usually a `delite/Widget`)
+based on the new values of the changed properties.
+The advantage compared to doing that in a custom setter
+is that for several properties changes the refresh rendering phase will be called only once,
+leading to better performance by making sure the rendering is not modified several times in a row.
+
+<a name="startup"></a>
+## Startup Lifecycle
+
+`decor/Invalidating` has an `initializeRendering()` method that it calls on startup, in order to do the initial
+rendering of the DOM.
+It also calls `computeProperties(this, true)` and `refreshRendering(this, true)`
+since those methods tend to have code that is useful for the initial rendering in addition to responding to changes.
+
+So, the startup lifecycle is:
+
+1. mix in the parameters passed to the constructor
+2. call `computeProperties(this, true)`
+3. call `initializeRendering()`
+4. call `refreshRendering(this, true)`
+
+Note that `delite/Widget` replaces the `initializeRendering()` method with `preRender()`, `render()`, and `postRender()`
+methods.
+
+<a name="implementing"></a>
+## Implementing a Subclass
+
+Once you have set up your class, you will need to implement the lifecycle methods to do the initial rendering,
+and then to react to property changes.
+This can be done by redefining the `computeProperties()`, `initializeRendering()`, and/or `refreshRendering()` methods.
+Both `computeProperties()` and `refreshRendering()` take as parameter a hash object which contains the name of the
+properties that have triggered the refresh action.  This is particularly useful when several properties are involved.
 
 ```js
 define(["dcl/dcl", "decor/Invalidating"/*, ...*/], function (dcl, Invalidating/*, ...*/) {
@@ -52,6 +84,9 @@ define(["dcl/dcl", "decor/Invalidating"/*, ...*/], function (dcl, Invalidating/*
         // do something logical that does not directly impact the DOM because "a" has changed
         // To access new value, access directly to `this.a`
       }
+    },
+    initializeRendering: function () {
+      // create the initial DOM
     },
     refreshRendering: function (oldValues) {
       if ("b" in oldValues) {
@@ -68,14 +103,27 @@ define(["dcl/dcl", "decor/Invalidating"/*, ...*/], function (dcl, Invalidating/*
 <a name="using"></a>
 ## Using Invalidating
 
-Once setup you don't need anything special to use the invalidating class. You just need to change one of the properties
-and the refresh methods will be called automatically for you.
+Once set up you don't need anything special to use the invalidating class.
+You just need to change one of the properties and the refresh methods will be called automatically for you.
 
 If for some reason you want to invalidate a particular property without setting it explicitly
 then you can call `notifyCurrentValue(property)`.
 
-In some cases you might want to force the rendering to occur right after a given property has been set. For that you can
-use `deliver()`.
+In some cases you might want to force the rendering to occur right after a given property has been set.
+For that you can use `deliver()`.
 
 In some cases you might want to avoid rendering from occurring even if a property was changed.
 For that you can use `discardChanges()`.
+
+<a name="rerender"></a>
+## Rerendering from scratch
+
+Usually `initializeRendering()` (or for `delite/Widget`, `render()`) will be called only once, when the widget is created.
+However, `decor/Invalidating` has some special code to allow the widget to be rerendered from scratch,
+i.e. code to call `initializeRendering()` again, when certain properties are changed.
+This is used by `delite/Widget` when the widget's template has been changed.
+
+You can trigger a second call to `initializeRendering()` by defining a `shouldInitializeRendering(oldValues)` method
+that returns true when you want `initializeRendering()` to be called.
+
+

--- a/tests/unit/Invalidating.js
+++ b/tests/unit/Invalidating.js
@@ -8,50 +8,85 @@ define([
 		name: "Invalidating",
 		"Basic": function () {
 			var dfd = this.async(1000),
-				invalidating = new (dcl([Invalidating], {
+				log = [],
+				invalidating = new (dcl(Invalidating, {
 					foo: undefined,
 					bar: undefined,
-					refreshRendering: dfd.callback(function (oldValues) {
-						assert.deepEqual(oldValues, {foo: "Foo0", bar: "Bar0"});
-					})
+					computeProperties: function(oldValues){
+						log.push({method: "computeProperties", oldValues: oldValues});
+					},
+					initializeRendering: function(){
+						log.push({method: "initializeRendering"});
+					},
+					refreshRendering: function(oldValues){
+						log.push({method: "refreshRendering", oldValues: oldValues});
+					}
 				}))({
 					foo: "Foo0",
 					bar: "Bar0"
 				});
-			// Changes after 1st addRenderingProperties() call should be delivered
+
+			// Initialization should call refreshRendering(this) etc. after properties are mixed in.
+			assert.strictEqual(log.length, 3, "initial");
+			assert.strictEqual(log[0].method, "computeProperties", "initial");
+			assert.strictEqual(log[1].method, "initializeRendering", "initial");
+			assert.strictEqual(log[2].method, "refreshRendering", "initial");
+			assert.strictEqual(log[2].oldValues.foo, "Foo0", "initial");
+			assert.strictEqual(log[2].oldValues.bar, "Bar0", "initial");
+
+			// Changes after first addRenderingProperties() call should be delivered.
+			// Second call to refreshRendering() should give changes.
+			log = [];
 			invalidating.bar = "Bar1";
 			invalidating.foo = "Foo1";
+			setTimeout(dfd.callback(function () {
+				assert.strictEqual(log.length, 2, "changes");
+				assert.strictEqual(log[0].method, "computeProperties", "changes");
+				assert.strictEqual(log[1].method, "refreshRendering", "changes");
+				assert.deepEqual(log[1].oldValues, {foo: "Foo0", bar: "Bar0"}, "changes");
+			}), 5);
 		},
 		"Property validation": function () {
 			var computePropertiesCallCount = 0,
 				dfd = this.async(1000),
+				cpLog = [], rrLog = [],
 				invalidating = new (dcl(Invalidating, {
 					foo: undefined,
-					computeProperties: dfd.rejectOnError(function () {
-						if (++computePropertiesCallCount > 1) {
-							throw new Error("computeProperties() should be called only once.");
-						}
-						if (this.foo < 0) {
+					computeProperties: function (oldValues) {
+						cpLog.push(oldValues);
+						if(this.foo < 0){
 							this.foo = 0;
 							this.discardComputing();
 						}
-					}),
-					refreshRendering: dfd.callback(function (oldValues) {
-						assert.deepEqual(oldValues, {foo: 1});
-					})
+					},
+					refreshRendering: function (oldValues) {
+						rrLog.push(oldValues);
+					}
 				}))({
 					foo: 1
 				});
+
+			// Initialization should call computeProperties() and refreshRendering(this) after properties are mixed in.
+			assert.strictEqual(cpLog.length, 1, "initial computeProperties() call");
+			assert.strictEqual(cpLog[0].foo, 1, "initial computeProperties() value");
+			assert.strictEqual(rrLog.length, 1, "initial refreshRendering()");
+
 			invalidating.foo = -1;
+			setTimeout(dfd.callback(function () {
+				assert.strictEqual(cpLog.length, 2, "second computeProperties() call");
+				assert.strictEqual(rrLog.length, 2, "second refreshRendering() call");
+				assert.deepEqual(rrLog[1], {foo: 1}, "second refreshRendering() value");
+			}), 5);
 		},
 		"Computed property": function () {
-			var computePropertiesCallCount = 0,
-				dfd = this.async(1000),
+			var dfd = this.async(1000),
+				cpLog = [], rrLog = [],
 				invalidating = new (dcl(Invalidating, {
 					foo: undefined,
 					bar: undefined,
 					baz: undefined,
 					computeProperties: dfd.rejectOnError(function (oldValues) {
+						cpLog.push(oldValues);
 						if ("foo" in oldValues && typeof this.foo === "string") {
 							this.bar = this.foo.replace(/^Foo/, "Bar");
 						}
@@ -61,52 +96,113 @@ define([
 						if ("baz" in oldValues && typeof this.baz === "string") {
 							this.foo = this.baz.replace(/^Baz/, "Foo");
 						}
-						++computePropertiesCallCount;
 					}),
-					refreshRendering: dfd.callback(function () {
-						assert.strictEqual(computePropertiesCallCount, 3);
-						assert.strictEqual(invalidating.foo, "Foo0");
-						assert.strictEqual(invalidating.bar, "Bar0");
-						assert.strictEqual(invalidating.baz, "Baz0");
-					})
+					refreshRendering: function (oldValues) {
+						rrLog.push(oldValues);
+					}
 				}))();
+
+			// Initialization should call computeProperties() and refreshRendering(this).
+			assert.strictEqual(cpLog.length, 1, "initial computeProperties() call");
+			assert.strictEqual(rrLog.length, 1, "initial refreshRendering()");
+
+			// Test how setting a single property can trigger multiple calls to computeProperties() before
+			// there's a single call to refreshRendering().
 			invalidating.foo = "Foo0";
+			setTimeout(dfd.callback(function () {
+				assert.strictEqual(cpLog.length, 4, "total computeProperties() calls after setting foo");
+				assert.strictEqual(invalidating.foo, "Foo0");
+				assert.strictEqual(invalidating.bar, "Bar0");
+				assert.strictEqual(invalidating.baz, "Baz0");
+			}), 5);
 		},
 		"Synchronous change delivery": function () {
-			var finishedMicrotask = false,
-				dfd = this.async(1000),
-				invalidating = new (dcl([Invalidating], {
+			var cpLog = [], rrLog = [],
+				invalidating = new (dcl(Invalidating, {
 					foo: undefined,
 					bar: undefined,
-					computeProperties: dfd.rejectOnError(function () {
-						invalidating.bar = "Bar1";
-						this.deliver();
-					}),
-					refreshRendering: dfd.callback(function (oldValues) {
-						assert.isFalse(finishedMicrotask);
-						assert.deepEqual(oldValues, {foo: "Foo0", bar: "Bar0"});
-					})
+					computeProperties: function (oldValues) {
+						if (this.foo === "Foo1"){
+							this.bar = "Bar1";
+							this.deliver();
+						}
+					},
+					refreshRendering: function (oldValues) {
+						rrLog.push(oldValues);
+					}
 				}))({
 					foo: "Foo0",
 					bar: "Bar0"
 				});
+			assert.strictEqual(rrLog.length, 1, "on creation, one call to refreshRendering()");
+
 			invalidating.foo = "Foo1";
 			invalidating.deliverComputing();
-			finishedMicrotask = true;
+			assert.strictEqual(rrLog.length, 2, "deliverComputing() triggered another call to refreshRendering()");
+			assert.deepEqual(rrLog[1], {foo: "Foo0", bar: "Bar0"});
 		},
 		"Discard changes": function () {
 			var dfd = this.async(1000),
-				invalidating = new (dcl([Invalidating], {
+				rrCalls = 0,
+				invalidating = new (dcl(Invalidating, {
 					foo: undefined,
-					refreshRendering: dfd.rejectOnError(function () {
-						throw new Error("refreshRendering() shouldn't be called.");
-					})
+					refreshRendering: function () {
+						rrCalls ++;
+					}
 				}))({
 					foo: "Foo0"
 				});
+			assert.strictEqual(rrCalls, 1, "refreshRendering() called on initialization");
+
 			invalidating.foo = "Foo1";
 			invalidating.discardChanges();
-			setTimeout(dfd.resolve.bind(dfd), 100);
+			setTimeout(dfd.callback(function () {
+				assert.strictEqual(rrCalls, 1, "refreshRendering() not called again due to discardChanges()");
+			}), 5);
+		},
+		"shouldInitializeRendering()": function () {
+			var dfd = this.async(1000),
+				log = [],
+				invalidating = new (dcl(Invalidating, {
+					foo: undefined,
+					bar: undefined,
+					template: undefined,
+					computeProperties: function(oldValues){
+						log.push("computeProperties");
+					},
+					shouldInitializeRendering: function (oldValues) {
+						log.push("shouldInitializeRendering");
+						return "template" in oldValues;
+					},
+					initializeRendering: function(){
+						log.push("initializeRendering");
+					},
+					refreshRendering: function(oldValues){
+						log.push("refreshRendering");
+					}
+				}))({
+					foo: "Foo0",
+					bar: "Bar0"
+				});
+
+			// On creation we call initializeRendering() unconditionally
+			assert.deepEqual(log, ["computeProperties", "initializeRendering", "refreshRendering"], "initial");
+
+			// Random change makes shouldInitializeRendering() return false, and initializeRendering() isn't called.
+			log = [];
+			invalidating.bar = "Bar1";
+			setTimeout(dfd.rejectOnError(function () {
+				assert.deepEqual(log, ["computeProperties", "shouldInitializeRendering", "refreshRendering"], "change");
+
+				// But changing "template" property makes shouldInitializeRendering() return true,
+				// triggering another call to initializeRendering().
+				log = [];
+				invalidating.template = 123;
+				setTimeout(dfd.callback(function () {
+					assert.deepEqual(log, ["computeProperties", "shouldInitializeRendering",  "initializeRendering",
+						"refreshRendering"], "rerender");
+				}), 5);
+			}), 5);
 		}
 	});
 });


### PR DESCRIPTION
Invalidating enhancements.

1. Creation lifecycle is now: `computeProperties(this)`,  `initializeRendering()`, and `refreshRendering(this)`.  Subclasses no longer need code like `this.notifyCurrentValue("dir")`.
3. Also adds `shouldInitializeRendering()` method that's called whenever properties are changed.  If `shouldInitializeRendering()` returns true, then  `initializeRendering()` is called again, thus rerendering the widget.  Otherwise, only `refreshRendering()` (and `computeProperties()`) are called.

Needed by code in ibm-js/delite#420.

Based on code from @asudoh (see #53), but with these changes:

* Do initialization delay in delite rather than decor.
* Doesn't add `deliverRendering()` and `discardRendering()` methods after all; they aren't needed anymore.
* When widget is rerendered, call `refreshRendering(this)` rather than `refreshRendering(oldValues)`.  This is consistent with the initial call to `refreshRendering()`.
* Allow initial `computeProperties()` call to trigger another immediate call to `computeProperties()`.  This is consistent with when `computeProperties()` is called due to incremental property updates.
* Added tests and doc.